### PR TITLE
JIT-47936: properly resolve element refs with empty namespace prefix

### DIFF
--- a/.run/test.run.xml
+++ b/.run/test.run.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="test" type="mocha-javascript-test-runner" nameIsGenerated="true">
+    <node-interpreter>project</node-interpreter>
+    <node-options />
+    <mocha-package>$PROJECT_DIR$/node_modules/mocha</mocha-package>
+    <working-directory>$PROJECT_DIR$</working-directory>
+    <pass-parent-env>true</pass-parent-env>
+    <ui>bdd</ui>
+    <extra-mocha-options />
+    <test-kind>DIRECTORY</test-kind>
+    <test-directory>$PROJECT_DIR$/test/</test-directory>
+    <recursive>false</recursive>
+    <method v="2" />
+  </configuration>
+</component>

--- a/src/parser/element.js
+++ b/src/parser/element.js
@@ -191,14 +191,17 @@ class Element {
     var nsURI;
     if (qname.prefix === 'xml') return null;
     if (qname.prefix) nsURI = this.getNamespaceURI(qname.prefix);
-    else nsURI = this.getTargetNamespace();
     qname.nsURI = nsURI;
+    var schema = schemas[qname.nsURI || ''];
     var name = qname.name;
     if (nsURI === helper.namespaces.xsd &&
       (elementType === 'simpleType' || elementType === 'type')) {
       return xsd.getBuiltinType(name);
     }
-    var schema = schemas[nsURI];
+    if (!schema) {
+      nsURI = this.getTargetNamespace();
+      schema = schemas[nsURI];
+    }
     if (!schema) {
       debug('Schema not found: %s (%s)', qname, elementType);
       return null;

--- a/src/parser/wsdl.js
+++ b/src/parser/wsdl.js
@@ -223,11 +223,11 @@ class WSDL {
 
       if (wsdl.definitions instanceof Definitions) {
         // Set namespace for included schema that does not have targetNamespace
-        if (undefined in wsdl.definitions.schemas) {
-          if (include.namespace != null) {
+        if ('' in wsdl.definitions.schemas) {
+          if (include.namespace !== null) {
             // If A includes B and B includes C, B & C can both have no targetNamespace
-            wsdl.definitions.schemas[include.namespace] = wsdl.definitions.schemas[undefined];
-            delete wsdl.definitions.schemas[undefined];
+            wsdl.definitions.schemas[include.namespace] = wsdl.definitions.schemas[''];
+            delete wsdl.definitions.schemas[''];
           }
         }
         _.mergeWith(self.definitions, wsdl.definitions, function (a, b) {

--- a/src/parser/wsdl/types.js
+++ b/src/parser/wsdl/types.js
@@ -21,7 +21,7 @@ class Types extends WSDLElement {
 
     if (child instanceof Schema) {
 
-      var targetNamespace = child.$targetNamespace;
+      var targetNamespace = child.$targetNamespace || '';
 
       if (!this.schemas.hasOwnProperty(targetNamespace)) {
         this.schemas[targetNamespace] = child;

--- a/src/parser/xsd/schema.js
+++ b/src/parser/xsd/schema.js
@@ -82,6 +82,10 @@ class Schema extends XSDElement {
     }
   }
 
+  getTargetNamespace() {
+    return this.$targetNamespace || '';
+  }
+
   postProcess(defintions) {
     var visited = new Set();
     visited.add(this);

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -278,7 +278,7 @@ describe('SOAP Server', function() {
       client.IsValidPrice({TradePrice: {price: 50000 }}, function(err, result) {
         // node V3.x+ reports addresses as IPV6
         var addressParts = lastReqAddress.split(':');
-        addressParts[(addressParts.length - 1)].should.equal('127.0.0.1');
+        assert.equal(addressParts[(addressParts.length - 1)], '127.0.0.1');
         done();
       });
     });

--- a/test/wsdl-parse-test.js
+++ b/test/wsdl-parse-test.js
@@ -85,7 +85,7 @@ describe(__filename, function() {
       function(err, def) {
         var schemas = def.definitions.schemas;
         assert.deepEqual(Object.keys(schemas), [
-          'undefined',
+          '',
           'http://company.de/cake/synonymelisten/webservice',
           'http://company.de/cake/synonymelisten',
           'http://company.de/cake/synonymelisten/webservice/exceptions'

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -164,6 +164,14 @@ describe('wsdl-tests', function() {
       });
     });
 
+    it('should find element refs with empty prefix', function (done) {
+      soap.createClient('https://wocastestsrvwa.woonstadrotterdam.nl/k2wservices.wsdl', {strict: true}, function(err, client) {
+        assert.ok(!err);
+        assert.deepEqual(Object.keys(client.wsdl.definitions.schemas), ['']);
+        done();
+      });
+    });
+
     //revisit -  If client class is modified, client.describe() will change.. it's pain to keep changing the 'expected'
     //output. What's the value of this test? Do we need this test? Skipping for now even though test passes currently.
     it.skip('should load same namespace from included xsd', function (done) {


### PR DESCRIPTION
Signed-off-by: William Bailey <william.bailey@jitterbit.com>

### Description
In the case that the schema referenced by a message part has no target namespace but the wsdl does, we were unable to resolve the element referenced by the part.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #321 

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
